### PR TITLE
feat: Implement cube cutting in WGSL shader

### DIFF
--- a/examples/moving_cut.rs
+++ b/examples/moving_cut.rs
@@ -13,18 +13,20 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(PlaneCutPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, (rotate_things, translate_things, update_plane))
+        // .add_systems(Update, (rotate_things, translate_things, update_plane)) // update_plane removed
+        .add_systems(Update, (rotate_things, translate_things))
         .run();
 }
 
-#[derive(Component)]
-struct Plane(Handle<PlaneCutMaterial>);
+// #[derive(Component)] // Plane component might not be needed if we don't update planes dynamically for now
+// struct Plane(Handle<PlaneCutMaterial>);
 
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<PlaneCutMaterial>>,
 ) {
+    let default_planes_ext = PlaneCutExt::default();
     let handle = materials.add(ExtendedMaterial {
         base: StandardMaterial {
             base_color: basic::RED.into(),
@@ -32,21 +34,21 @@ fn setup(
             ..Default::default()
         },
         extension: PlaneCutExt {
-            plane: Vec4::new(-1.0, 1.0, -2.0, 0.0),
-            color: Color::linear_rgb(0.0, 0.0, 0.7),
-            shaded: true,
-            space: Space::World,
+            planes: default_planes_ext.planes, // Use default planes for a unit cube
+            color: Color::linear_rgb(0.0, 0.0, 0.7), // Keep custom color
+            shaded: true,                       // Keep custom shaded setting
+            space: Space::World,                // Keep custom space
         },
     });
-    commands.spawn((
-        TransformBundle {
-            local: Transform { ..default() },
-            ..default()
-        },
-        Plane(handle.clone()),
-        // Rotate(Vec3::new(1.0, 1.0, 0.0))
-        Translate(Vec3::new(1.0, 0.0, 0.0)),
-    ));
+    // commands.spawn(( // Spawning a separate entity to control the plane might not be needed for a static cube
+    //     TransformBundle {
+    //         local: Transform { ..default() },
+    //         ..default()
+    //     },
+    //     Plane(handle.clone()),
+    //     // Rotate(Vec3::new(1.0, 1.0, 0.0))
+    //     Translate(Vec3::new(1.0, 0.0, 0.0)),
+    // ));
     // sphere
     commands.spawn(MaterialMeshBundle {
         mesh: meshes.add(Sphere::new(1.0)),
@@ -71,20 +73,22 @@ fn setup(
     });
 }
 
-fn update_plane(
-    q: Query<(&GlobalTransform, &Plane)>,
-    mut materials: ResMut<Assets<PlaneCutMaterial>>,
-) {
-    for (t, p) in &q {
-        let Some(m) = materials.get_mut(&p.0) else {
-            continue;
-        };
-        trace!("Updating plane");
-        let normal = t.left();
-        let w = normal.dot(t.translation());
-        m.extension.plane = (*normal, w).into();
-    }
-}
+// fn update_plane(
+//     q: Query<(&GlobalTransform, &Plane)>,
+//     mut materials: ResMut<Assets<PlaneCutMaterial>>,
+// ) {
+//     for (t, p) in &q {
+//         let Some(m) = materials.get_mut(&p.0) else {
+//             continue;
+//         };
+//         trace!("Updating plane");
+//         // This logic was for a single plane. For multiple planes, this would need to be redesigned.
+//         // For a static cube, this system is not needed.
+//         // let normal = t.left();
+//         // let w = normal.dot(t.translation());
+//         // m.extension.plane = (*normal, w).into();
+//     }
+// }
 
 #[derive(Component)]
 struct Translate(Vec3);


### PR DESCRIPTION
This commit updates the plane_cut WGSL shader and associated Rust code to support cutting with a cube defined by 6 planes, instead of a single plane.

Changes include:
- Modified `PlaneCutExt` struct in both `src/lib.rs` and `src/plane_cut.wgsl` to use an array of 6 `Vec4` / `vec4<f32>` for planes.
- Updated the default `PlaneCutExt` values in `src/lib.rs` to define an axis-aligned unit cube.
- Modified the WGSL shader logic to iterate through the 6 planes and discard fragments outside any of them.
- Implemented a simplified approach for shaded backface normals by using the normal of the first plane in the array.
- Updated the `examples/moving_cut.rs` example to demonstrate a static cube cut, commenting out the previous single-plane animation logic.